### PR TITLE
Update builder method to reference lib/views

### DIFF
--- a/lib/sinatra/soap.rb
+++ b/lib/sinatra/soap.rb
@@ -21,7 +21,6 @@ module Sinatra
       app.set :namespace, 'http://schemas.xmlsoap.org/wsdl/' unless defined?(app.settings.namespace)
       app.set :endpoint, '/action' unless defined?(app.settings.endpoint)
       app.set :service, 'Sinatra' unless defined?(app.settings.service)
-      app.set :sinatra_soap_views,  File.join(File.dirname(__FILE__),"views") unless defined?(app.settings.sinatra_soap_views)
 
       app.post(app.settings.endpoint) do
         content_type 'text/xml'
@@ -33,7 +32,6 @@ module Sinatra
         get_wsdl
       end
     end
-
   end
   Delegator.delegate :soap
   register Soap

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -2,12 +2,17 @@ module Sinatra
   module Soap
     module HelperMethods
 
+      # Return the location where we can find our views
+      def soap_views()
+        File.join(File.dirname(__FILE__), "..", "views")
+      end
+
       def call_action_block
         request = Soap::Request.new(env, request, params)
         response = request.execute
-        builder :response, locals: {wsdl: response.wsdl, params: response.params}, :views => settings.sinatra_soap_views
+        builder :response, locals: {wsdl: response.wsdl, params: response.params}, :views => self.soap_views
       rescue Soap::Error => e
-        builder :error, locals: {e: e}, :views => settings.sinatra_soap_views
+        builder :error, locals: {e: e}, :views => self.soap_views
       end
 
       def get_wsdl
@@ -19,10 +24,9 @@ module Sinatra
             raise "No wsdl file"
           end
         else
-          builder :wsdl, locals: {wsdl: Soap::Wsdl.actions}, :views => settings.sinatra_soap_views
+          builder :wsdl, locals: {wsdl: Soap::Wsdl.actions}, :views => self.soap_views
         end
       end
-
     end
   end
 end

--- a/spec/soap_spec.rb
+++ b/spec/soap_spec.rb
@@ -5,7 +5,6 @@ describe 'A default soap sinatra application' do
   def app
     SoapApp 
   end
-  
 
   it "should parse soap request and send response" do
     headers = {"HTTP_SOAPACTION" => 'test'}
@@ -53,6 +52,11 @@ describe 'A default soap sinatra application' do
   it "should have route for wsdl" do
     wsdl = app.routes["GET"].select {|k| k[0].to_s.match('wsdl')}.count
     wsdl.should == 1
+  end
+
+  it "should return a usable soap views directory" do
+    view_search = File.join(app.views, "*.builder")
+    expect(Dir.glob(view_search).count).to be > 0
   end
 
 end


### PR DESCRIPTION
Hey There,
   I was surprised when the builder templates were being looked for in my app's views directory.  I went ahead and fixed that.  

I still ran into some issues generating a wsdl including this line:

(formats[:in] + formats[:out]).each do |p|  #  Hash has no method '+" method.  I changed to use merge! and got past that.

then I failed on "wsdl_type".  I assume this is because you are still porting some of the wash_out methods?

Thanks,

Anthony
