### PR TITLE
Add some features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .rvmrc
 *.swp*.gem
 Gemfile.lock
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 before_install:
   - gem install bundler
+
 rvm:
-  - 2.0.0
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
   - gem install bundler
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.4.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sinatra-soap.gemspec
 gemspec
+
+gem 'sinatra', '2.0.0.rc2'

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -10,6 +10,9 @@ module Sinatra
       end
 
       def hash_to_xml(xml, hash)
+        unless hash.is_a?(Hash)
+          raise ArgumentError, "content must be a hash"
+        end
         hash.each do |key, value|
           if value.is_a?(Hash)
             attrs = {}
@@ -66,7 +69,7 @@ module Sinatra
       end
 
       def call_action_block
-        request = Soap::Request.new(env, request, params)
+        request = Soap::Request.new(env, request, params, self)
         if defined?(logger) && logger
           logger.info "SOAP Request: #{request.action}"
         end

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -78,15 +78,12 @@ module Sinatra
         }
       rescue Soap::Error => e
         if defined?(logger) && logger
-          logger.info "SOAP Request: #{env['HTTP_SOAPACTION']} - Undefined Soap Action"
+          logger.error "SOAP Error: #{e.message} - Action: #{env['HTTP_SOAPACTION']}"
         end
         builder :error, locals: {e: e}, views: self.soap_views
       end
 
       def get_wsdl
-        if defined?(logger) && logger
-          logger.info "SOAP: wsdl request"
-        end
         if defined?(settings.wsdl_path)
           path = File.join(settings.public_folder, settings.wsdl_path)
           if File.exist?(path)

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -32,15 +32,31 @@ module Sinatra
               end
             end
           elsif value.is_a?(Array)
-            # TODO: proper rendering. if we have array of hashes then each hash should be a tag with singulular name of parent key
-            xml.tag!(key) do
+            parent_tag = singularize(key)
+
+            if parent_tag == key.to_s
               value.each do |value|
-                hash_to_xml(xml, value)
+                hash_to_xml(xml, parent_tag => value)
+              end
+            else
+              xml.tag!(key) do
+                value.each do |value|
+                  hash_to_xml(xml, parent_tag => value)
+                end
               end
             end
           else
             xml.tag! key, value
           end
+        end
+      end
+
+      def singularize(word)
+        word = word.to_s
+        if word.respond_to?(:singularize)
+          word.singularize
+        else
+          word.sub(/(c|s|x)es$/, '\1').sub(/s$/, '')
         end
       end
 

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -31,6 +31,13 @@ module Sinatra
                 hash_to_xml(xml, content)
               end
             end
+          elsif value.is_a?(Array)
+            # TODO: proper rendering. if we have array of hashes then each hash should be a tag with singulular name of parent key
+            xml.tag!(key) do
+              value.each do |value|
+                hash_to_xml(xml, value)
+              end
+            end
           else
             xml.tag! key, value
           end
@@ -49,6 +56,9 @@ module Sinatra
           soap_headers: response.headers
         }
       rescue Soap::Error => e
+        if defined?(logger) && logger
+          logger.info "SOAP Request: #{env['HTTP_SOAPACTION']} - Undefined Soap Action"
+        end
         builder :error, locals: {e: e}, views: self.soap_views
       end
 

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -14,15 +14,22 @@ module Sinatra
           if value.is_a?(Hash)
             attrs = {}
             content = {}
+            content_str = nil
             value.each do |key, value|
-              if key.to_s.start_with?("@")
+              if key.to_s == "@@content"
+                content_str = value
+              elsif key.to_s.start_with?("@")
                 attrs[key.to_s[1..-1]] = value
               else
                 content[key] = value
               end
             end
-            xml.tag!(key, attrs) do
-              hash_to_xml(xml, content)
+            if content_str
+              xml.tag!(key, attrs, content_str)
+            else
+              xml.tag!(key, attrs) do
+                hash_to_xml(xml, content)
+              end
             end
           else
             xml.tag! key, value

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -9,6 +9,27 @@ module Sinatra
         File.join(File.dirname(__FILE__), "..", "views")
       end
 
+      def hash_to_xml(xml, hash)
+        hash.each do |key, value|
+          if value.is_a?(Hash)
+            attrs = {}
+            content = {}
+            value.each do |key, value|
+              if key.to_s.start_with?("@")
+                attrs[key.to_s[1..-1]] = value
+              else
+                content[key] = value
+              end
+            end
+            xml.tag!(key, attrs) do
+              hash_to_xml(xml, content)
+            end
+          else
+            xml.tag! key, value
+          end
+        end
+      end
+
       def call_action_block
         request = Soap::Request.new(env, request, params)
         if defined?(logger) && logger

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -51,12 +51,17 @@ module Sinatra
         end
       end
 
+      # Try to use activesupport's singularize, failback to simplified implementation
       def singularize(word)
         word = word.to_s
         if word.respond_to?(:singularize)
           word.singularize
         else
-          word.sub(/(c|s|x)es$/, '\1').sub(/s$/, '')
+          if word =~ /(c|s|x)es$/
+            word.sub(/(c|s|x)es$/, '\1')
+          else
+            word.sub(/s$/, '')
+          end
         end
       end
 

--- a/lib/sinatra/soap/helper_methods.rb
+++ b/lib/sinatra/soap/helper_methods.rb
@@ -11,13 +11,23 @@ module Sinatra
 
       def call_action_block
         request = Soap::Request.new(env, request, params)
+        if defined?(logger) && logger
+          logger.info "SOAP Request: #{request.action}"
+        end
         response = request.execute
-        builder :response, locals: {wsdl: response.wsdl, params: response.params}, :views => self.soap_views
+        builder :response, views: self.soap_views, locals: {
+          wsdl: response.wsdl,
+          params: response.params,
+          soap_headers: response.headers
+        }
       rescue Soap::Error => e
-        builder :error, locals: {e: e}, :views => self.soap_views
+        builder :error, locals: {e: e}, views: self.soap_views
       end
 
       def get_wsdl
+        if defined?(logger) && logger
+          logger.info "SOAP: wsdl request"
+        end
         if defined?(settings.wsdl_path)
           path = File.join(settings.public_folder, settings.wsdl_path)
           if File.exist?(path)
@@ -26,7 +36,7 @@ module Sinatra
             raise "No wsdl file"
           end
         else
-          builder :wsdl, locals: {wsdl: Soap::Wsdl.actions}, :views => self.soap_views
+          builder :wsdl, locals: {wsdl: Soap::Wsdl.actions}, views: self.soap_views
         end
       end
 

--- a/lib/sinatra/soap/request.rb
+++ b/lib/sinatra/soap/request.rb
@@ -54,6 +54,8 @@ module Sinatra
         orig_params[:soap_header] = nori.parse(rack_input)[:Envelope][:Header]
       end
 
+      alias_method :soap_header, :header
+
       def wsdl
         @wsdl = Soap::Wsdl.new(action)
       end

--- a/lib/sinatra/soap/request.rb
+++ b/lib/sinatra/soap/request.rb
@@ -4,7 +4,7 @@ module Sinatra
   module Soap
     class Request
 
-      attr_reader :wsdl, :action, :env, :request, :params
+      attr_reader :wsdl, :action, :env, :request, :params, :response
 
       def initialize(env, request, params)
         @env = env
@@ -16,8 +16,18 @@ module Sinatra
 
       def execute
         request_block = wsdl.block
+        @response = Soap::Response.new(wsdl, nil)
         response_hash = self.instance_eval(&request_block)
-        Soap::Response.new(wsdl, response_hash)
+
+        if @response.params == nil
+          if response_hash.is_a?(Array)
+            @response.params, @response.headers = response_hash
+          else
+            @response.params = response_hash
+          end
+        end
+
+        @response
       end
 
       alias_method :orig_params, :params

--- a/lib/sinatra/soap/request.rb
+++ b/lib/sinatra/soap/request.rb
@@ -6,10 +6,13 @@ module Sinatra
 
       attr_reader :wsdl, :action, :env, :request, :params, :response
 
+      alias_method :body, :params
+
       def initialize(env, request, params)
         @env = env
         @request = request
         @params = params
+        @header = {}
         parse_request
       end
 
@@ -37,14 +40,19 @@ module Sinatra
         orig_params[:action] = env['HTTP_SOAPACTION'].to_s.gsub(/^"(.*)"$/, '\1').to_sym
       end
 
-
-      def params 
+      def params
         return orig_params[:soap] unless orig_params[:soap].nil?
         rack_input = env["rack.input"].read
         env["rack.input"].rewind
         orig_params[:soap] = nori.parse(rack_input)[:Envelope][:Body][action]
       end
 
+      def header
+        return orig_params[:soap_header] unless orig_params[:soap_header].nil?
+        rack_input = env["rack.input"].read
+        env["rack.input"].rewind
+        orig_params[:soap_header] = nori.parse(rack_input)[:Envelope][:Header]
+      end
 
       def wsdl
         @wsdl = Soap::Wsdl.new(action)

--- a/lib/sinatra/soap/request.rb
+++ b/lib/sinatra/soap/request.rb
@@ -8,11 +8,12 @@ module Sinatra
 
       alias_method :body, :params
 
-      def initialize(env, request, params)
+      def initialize(env, request, params, app)
         @env = env
         @request = request
         @params = params
         @header = {}
+        @app = app
         parse_request
       end
 
@@ -58,6 +59,10 @@ module Sinatra
 
       def wsdl
         @wsdl = Soap::Wsdl.new(action)
+      end
+
+      def method_missing(method_name, *args, &blok)
+        @app.send(method_name, *args, &blok)
       end
 
       private

--- a/lib/sinatra/soap/response.rb
+++ b/lib/sinatra/soap/response.rb
@@ -2,11 +2,13 @@ module Sinatra
   module Soap
     class Response
 
-      attr_reader :wsdl, :params
+      attr_reader :wsdl
+      attr_accessor :params, :headers
 
-      def initialize(wsdl, params)
+      def initialize(wsdl, params, headers = nil)
         @wsdl = wsdl
         @params = params
+        @headers = headers
       end
     end
   end

--- a/lib/sinatra/soap/response.rb
+++ b/lib/sinatra/soap/response.rb
@@ -5,6 +5,9 @@ module Sinatra
       attr_reader :wsdl
       attr_accessor :params, :headers
 
+      alias_method :body, :params
+      alias_method :body=, :params=
+
       def initialize(wsdl, params, headers = nil)
         @wsdl = wsdl
         @params = params

--- a/lib/sinatra/soap/wsdl.rb
+++ b/lib/sinatra/soap/wsdl.rb
@@ -20,13 +20,14 @@ module Sinatra
       def self.generate
       end
 
-      attr_accessor :action, :block, :arguments
+      attr_accessor :action, :block, :arguments, :reply_name
 
       def initialize(action)
         data = all[action]
         raise Soap::Error, "Undefined Soap Action" if data.nil?
         @action = action
         @block = data[:block]
+        @reply_name = data[:reply_name]
         @arguments = data.select {|k,v| k != :block}
       end
 

--- a/lib/sinatra/views/response.builder
+++ b/lib/sinatra/views/response.builder
@@ -1,17 +1,14 @@
 xml.instruct!
-xml.SOAP :Envelope do
+xml.tag! 'soap:Envelope', 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' do
   if soap_headers
     xml.tag! 'soap:Header' do
-      soap_headers.each do |key, value|
-        xml.tag! key, value
-      end
+      hash_to_xml(xml, soap_headers)
     end
   end
   xml.tag! 'soap:Body' do
     xml.tag! "soap:#{wsdl.reply_name || "#{wsdl.action}Response"}" do
-      params.each do |key, value|
-        xml.tag! key, value
-      end
+      hash_to_xml(xml, params)
     end
   end
 end

--- a/lib/sinatra/views/response.builder
+++ b/lib/sinatra/views/response.builder
@@ -1,9 +1,15 @@
 xml.instruct!
-xml.tag! 'soap:Envelope', 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' do
+xml.SOAP :Envelope do
+  if soap_headers
+    xml.tag! 'soap:Header' do
+      soap_headers.each do |key, value|
+        xml.tag! key, value
+      end
+    end
+  end
   xml.tag! 'soap:Body' do
-    xml.tag! "soap:#{wsdl.action}Response" do
-      params.each do |key, value| 
+    xml.tag! "soap:#{wsdl.reply_name || "#{wsdl.action}Response"}" do
+      params.each do |key, value|
         xml.tag! key, value
       end
     end

--- a/lib/sinatra/views/wsdl.builder
+++ b/lib/sinatra/views/wsdl.builder
@@ -12,8 +12,8 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     xml.tag! "schema", :targetNamespace => settings.namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema' do
       defined = []
       wsdl.each do |operation, formats|
-        formats[:in]||={}
-        formats[:out]||={}
+        formats[:in]  ||= {}
+        formats[:out] ||= {}
         formats[:in].each do |p|
           wsdl_type xml, p, defined
         end
@@ -28,7 +28,8 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     wsdl.keys.each do |operation|
       xml.operation :name => operation do
         xml.input :message => "tns:#{operation}"
-        xml.output :message => "tns:#{operation}Response"
+        response_name = wsdl[operation][:reply_name] || "#{operation}Response"
+        xml.output :message => "tns:#{response_name}"
       end
     end
   end
@@ -66,7 +67,8 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
 #, :name => param.name, :type => param.namespaced_type)
       end
     end
-    xml.message :name => "#{operation}Response" do
+    response_name = wsdl[operation][:reply_name] || "#{operation}Response"
+    xml.message :name => response_name do
       formats[:out] ||= []
       formats[:out].each do |p|
         xml.part wsdl_occurence(p, false)

--- a/sinatra-soap.gemspec
+++ b/sinatra-soap.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
-  spec.add_development_dependency "debugger"
+  #spec.add_development_dependency "debugger"
 
 
   spec.add_runtime_dependency "builder"

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -27,4 +27,23 @@ describe "Request" do
     expect(last_response.body).to eq(response + "\n")
   end
 
+  it "should render xml with params and single content" do
+    headers = {"HTTP_SOAPACTION" => 'test_render2'}
+    message = '<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="any" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:test></wsdl:test></env:Body></env:Envelope>'
+    post '/action', message, headers
+
+    response = %{
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <soap:test_render2Response>
+      <result status="success">
+        <foo active="true">bar</foo>
+      </result>
+    </soap:test_render2Response>
+  </soap:Body>
+</soap:Envelope>}.strip
+
+    expect(last_response.body).to eq(response + "\n")
+  end
 end

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe "Request" do
+  def app
+    SoapApp
+  end
+
+  it "should render xml with params" do
+    headers = {"HTTP_SOAPACTION" => 'test_render'}
+    message = '<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="any" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:test></wsdl:test></env:Body></env:Envelope>'
+    post '/action', message, headers
+
+    response = %{
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <soap:TestRenderReply>
+      <top>
+        <child attr1="attr_value">
+          <value>content</value>
+        </child>
+      </top>
+    </soap:TestRenderReply>
+  </soap:Body>
+</soap:Envelope>}.strip
+
+    expect(last_response.body).to eq(response + "\n")
+  end
+
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -2,29 +2,32 @@ require 'spec_helper'
 
 describe "Request" do
   def app
-    SoapApp 
+    SoapApp
   end
 
   before :each do 
     headers = {"HTTP_SOAPACTION" => 'test'}
-    message = '<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="any" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:test><par>one</par><par2>bar</par2><foo>wat</foo></wsdl:test></env:Body></env:Envelope>'
+    message = '<?xml version="1.0" encoding="UTF-8"?>' +
+              '<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+                'xmlns:wsdl="any" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">' +
+              '<env:Body><wsdl:test><par>one</par><par2>bar</par2><foo>wat</foo></wsdl:test></env:Body></env:Envelope>'
     post '/action', message, headers
     @request = Sinatra::Soap::Request.new(last_request.env, last_request, last_request.params)
   end
 
-  it "should get soap_action" do 
+  it "should get soap_action" do
     expect(@request.action).to eq(:test)
   end
 
-  it "should get soap arguments" do 
+  it "should get soap arguments" do
     expect(@request.params).to eq({par: "one", par2: "bar", foo: "wat"})
   end
 
-  it "should build response" do 
+  it "should build response" do
     expect(@request.execute).to be_an_instance_of(Sinatra::Soap::Response)
   end
 
-  it "should validate input with WSDL" do 
-    pending
+  it "should validate input with WSDL" do
+    skip
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -12,7 +12,7 @@ describe "Request" do
                 'xmlns:wsdl="any" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">' +
               '<env:Body><wsdl:test><par>one</par><par2>bar</par2><foo>wat</foo></wsdl:test></env:Body></env:Envelope>'
     post '/action', message, headers
-    @request = Sinatra::Soap::Request.new(last_request.env, last_request, last_request.params)
+    @request = Sinatra::Soap::Request.new(last_request.env, last_request, last_request.params, nil)
   end
 
   it "should get soap_action" do

--- a/spec/soap_spec.rb
+++ b/spec/soap_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'A default soap sinatra application' do
   def app
-    SoapApp 
+    SoapApp
   end
 
   it "should parse soap request and send response" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,18 @@ class SoapApp < Sinatra::Base
       }
     }
   end
+
+  soap :test_render2 do
+    {
+      result: {
+        "@status": "success",
+        foo: {
+          "@active": true,
+          "@@content": "bar"
+        }
+      }
+    }
+  end
 end
 
 module RSpecMixin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 ENV['RACK_ENV'] = 'test'
-require File.join(File.join(File.expand_path(File.dirname(__FILE__))), '..', 'lib', 'sinatra', 'soap')
+
+require_relative '../lib/sinatra/soap'
 require 'rspec'
 require 'rack/test'
 
@@ -11,10 +12,21 @@ class SoapApp < Sinatra::Base
 
   soap :add_circle, in: {circle: {center: {x: :integer, y: :integer}, 
                                   radius: :double}},
-            				out: nil do
-  	params #=> {circle: {center: {x: 3, y: 2}, radius: 12.0} }
-  	nil
-	end
+                    out: nil do
+    params #=> {circle: {center: {x: 3, y: 2}, radius: 12.0} }
+    nil
+  end
+
+  soap :test_render, reply_name: 'TestRenderReply' do
+    {
+      top: {
+        child: {
+          value: "content",
+          "@attr1": "attr_value"
+        }
+      }
+    }
+  end
 end
 
 module RSpecMixin

--- a/spec/views/response.builder
+++ b/spec/views/response.builder
@@ -1,9 +1,16 @@
 xml.instruct!
 xml.tag! 'soap:Envelope', 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
         'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' do
+  if soap_headers
+    xml.tag! 'soap:Header' do
+      soap_headers.each do |key, value|
+        xml.tag! key, value
+      end
+    end
+  end
   xml.tag! 'soap:Body' do
     xml.tag! "soap:#{wsdl.action}Response" do
-      params.each do |key, value| 
+      params.each do |key, value|
         xml.tag! key, value
       end
     end

--- a/spec/views/response.builder
+++ b/spec/views/response.builder
@@ -3,16 +3,12 @@ xml.tag! 'soap:Envelope', 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envel
         'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' do
   if soap_headers
     xml.tag! 'soap:Header' do
-      soap_headers.each do |key, value|
-        xml.tag! key, value
-      end
+      hash_to_xml(xml, soap_headers)
     end
   end
   xml.tag! 'soap:Body' do
-    xml.tag! "soap:#{wsdl.action}Response" do
-      params.each do |key, value|
-        xml.tag! key, value
-      end
+    xml.tag! "soap:#{wsdl.reply_name || "#{wsdl.action}Response"}" do
+      hash_to_xml(xml, params)
     end
   end
 end

--- a/spec/views/wsdl.builder
+++ b/spec/views/wsdl.builder
@@ -12,8 +12,8 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     xml.tag! "schema", :targetNamespace => settings.namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema' do
       defined = []
       wsdl.each do |operation, formats|
-        formats[:in]||={}
-        formats[:out]||={}
+        formats[:in]  ||= {}
+        formats[:out] ||= {}
         formats[:in].each do |p|
           wsdl_type xml, p, defined
         end
@@ -28,7 +28,8 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     wsdl.keys.each do |operation|
       xml.operation :name => operation do
         xml.input :message => "tns:#{operation}"
-        xml.output :message => "tns:#{operation}Response"
+        response_name = wsdl[operation][:reply_name] || "#{operation}Response"
+        xml.output :message => "tns:#{response_name}"
       end
     end
   end
@@ -54,19 +55,22 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
 
   xml.service :name => "service" do
     xml.port :name => "#{settings.service}_port", :binding => "tns:#{settings.service}_binding" do
-      xml.tag! "soap:address", :location => send("#{settings.service}_action_url")
+      xml.tag! "soap:address", :location => "http://#{request.host_with_port}#{settings.endpoint}"
     end
   end
 
   wsdl.each do |operation, formats|
     xml.message :name => "#{operation}" do
+      formats[:in] ||= []
       formats[:in].each do |p|
-        xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
+        xml.part wsdl_occurence(p, false)
       end
     end
-    xml.message :name => "#{operation}Response}" do
+    response_name = wsdl[operation][:reply_name] || "#{operation}Response"
+    xml.message :name => response_name do
+      formats[:out] ||= []
       formats[:out].each do |p|
-        xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
+        xml.part wsdl_occurence(p, false)
       end
     end
   end

--- a/spec/wsdl_spec.rb
+++ b/spec/wsdl_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe "WSDL" do
 
-  def wsdl 
+  def wsdl
     Sinatra::Soap::Wsdl
   end
 
@@ -11,7 +11,7 @@ describe "WSDL" do
     [:test, :add_circle].each do |action|
       expect(wsdl.actions).to include(action)
     end
-  end 
+  end
 
   it "should hold blocks for registered actions" do
     [:test, :add_circle].each do |action|


### PR DESCRIPTION
Added:

* `reply_name:` param. e.g. `soap :action, reply_name: 'ActionReply' do ... end`
* add optional `soap:Header`
* add access to `response` object:
```ruby
soap :action do
  response.headers = { foo: "bar" }
  response.params = { status: "success" }
  # or
  [{ foo: "bar" }, { status: "success" }]
end
```
* attribute keys:
```ruby
soap :action do
  {
    result: {
      "@status": "success",
      foo: {
        "@active": true,
        "@@content": "bar"
      }
    }
  }
end
# output:
<result status="success">
  <foo active="true">bar</foo>
</result>
```

If you find this useful, I will add more tests and documentation